### PR TITLE
Interface config review

### DIFF
--- a/plugins/module_utils/firewall_alias_utils.py
+++ b/plugins/module_utils/firewall_alias_utils.py
@@ -311,7 +311,7 @@ class FirewallAliasSet(OPNsenseModuleConfig):
             config_context_names=[
                 "firewall_alias",
                 "system_access_users",
-                "interfaces_assignments",
+                "interfaces_configuration",
             ],
             path=path,
         )
@@ -727,7 +727,7 @@ class FirewallAliasSet(OPNsenseModuleConfig):
         # longer needed and to avoid the configure_functions in
         # the save() method, they can be popped
         self._config_maps.pop("system_access_users")
-        self._config_maps.pop("interfaces_assignments")
+        self._config_maps.pop("interfaces_configuration")
 
         if not self.changed:
             return False

--- a/plugins/module_utils/interfaces_configuration_utils.py
+++ b/plugins/module_utils/interfaces_configuration_utils.py
@@ -430,24 +430,13 @@ class InterfacesSet(OPNsenseModuleConfig):
             return False
 
         # Use 'find' to get the single parent element
-        parent_element = self._config_xml_tree.find(
+        interfaces_element = self._config_xml_tree.find(
             self._config_maps["interfaces_configuration"]["interfaces"]
         )
 
-        # Assuming 'parent_element' correctly refers to the container of interface elements
-        for interface_element in list(parent_element):
-            parent_element.remove(interface_element)
-
-        # Now, add updated interface elements
-        parent_element.extend(
-            [
-                interface_configuration.to_etree()
-                for interface_configuration in self._interfaces_configuration
-            ]
+        interfaces_element.clear()
+        interfaces_element.extend(
+            [interface_configuration.to_etree() for interface_configuration in self._interfaces_configuration]
         )
 
-        # Write the updated XML tree to the file
-        tree = ElementTree(self._config_xml_tree)
-        tree.write(self._config_path, encoding="utf-8", xml_declaration=True)
-
-        return True
+        return super().save(override_changed=True)

--- a/tests/unit/plugins/module_utils/test_firewall_alias_utils.py
+++ b/tests/unit/plugins/module_utils/test_firewall_alias_utils.py
@@ -51,7 +51,7 @@ TEST_VERSION_MAP = {
             ],
             "configure_functions": {},
         },
-        "interfaces_assignments": {
+        "interfaces_configuration": {
             "interfaces": "interfaces",
             "php_requirements": [],
             "configure_functions": {},

--- a/tests/unit/plugins/module_utils/test_interfaces_configuration_utils.py
+++ b/tests/unit/plugins/module_utils/test_interfaces_configuration_utils.py
@@ -1302,7 +1302,7 @@ def test_interface_configuration_from_ansible_module_params_with_description_upd
         test_interface_configuration: InterfaceConfiguration = (
             InterfaceConfiguration.from_ansible_module_params(test_params)
         )
-        interfaces_set.update(test_interface_configuration)
+        interfaces_set.add_or_update(test_interface_configuration)
         assert interfaces_set.changed
 
         interfaces_set.save()
@@ -1336,7 +1336,7 @@ def test_interface_configuration_from_ansible_module_params_with_device_update(
         test_interface_configuration: InterfaceConfiguration = (
             InterfaceConfiguration.from_ansible_module_params(test_params)
         )
-        interfaces_set.update(test_interface_configuration)
+        interfaces_set.add_or_update(test_interface_configuration)
         assert interfaces_set.changed
         interfaces_set.save()
 
@@ -1370,7 +1370,7 @@ def test_interface_configuration_from_ansible_module_params_with_not_existing_de
             test_interface_configuration: InterfaceConfiguration = (
                 InterfaceConfiguration.from_ansible_module_params(test_params)
             )
-            interfaces_set.update(test_interface_configuration)
+            interfaces_set.add_or_update(test_interface_configuration)
             interfaces_set.save()
         assert "Interface was not found on OPNsense Instance!" in str(excinfo.value)
 
@@ -1397,7 +1397,7 @@ def test_interface_configuration_from_ansible_module_params_with_not_existing_id
             test_interface_configuration: InterfaceConfiguration = (
                 InterfaceConfiguration.from_ansible_module_params(test_params)
             )
-            interfaces_set.update(test_interface_configuration)
+            interfaces_set.add_or_update(test_interface_configuration)
             interfaces_set.save()
         assert (
             "This device is already assigned, please unassign this device first"
@@ -1426,7 +1426,7 @@ def test_interface_configuration_from_ansible_module_params_with_not_existing_id
         test_interface_configuration: InterfaceConfiguration = (
             InterfaceConfiguration.from_ansible_module_params(test_params)
         )
-        interfaces_set.update(test_interface_configuration)
+        interfaces_set.add_or_update(test_interface_configuration)
         assert interfaces_set.changed
         interfaces_set.save()
 
@@ -1460,7 +1460,7 @@ def test_interface_configuration_from_ansible_module_params_with_duplicate_devic
             test_interface_configuration: InterfaceConfiguration = (
                 InterfaceConfiguration.from_ansible_module_params(test_params)
             )
-            interfaces_set.update(test_interface_configuration)
+            interfaces_set.add_or_update(test_interface_configuration)
             interfaces_set.save()
         assert (
             "This device is already assigned, please unassign this device first"

--- a/tests/unit/plugins/module_utils/test_interfaces_configuration_utils.py
+++ b/tests/unit/plugins/module_utils/test_interfaces_configuration_utils.py
@@ -3,13 +3,11 @@
 # pylint: skip-file
 import os
 from tempfile import NamedTemporaryFile
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from xml.etree import ElementTree
 from xml.etree.ElementTree import Element
 
-
 import pytest
-
 from ansible_collections.puzzle.opnsense.plugins.module_utils import xml_utils
 from ansible_collections.puzzle.opnsense.plugins.module_utils.interfaces_configuration_utils import (
     InterfaceConfiguration,
@@ -30,6 +28,7 @@ TEST_VERSION_MAP = {
             "php_requirements": [],
             "configure_functions": {},
         },
+
     }
 }
 
@@ -464,12 +463,12 @@ TEST_XML: str = """<?xml version="1.0"?>
                 <updated>
                 <username>root@10.0.5.2</username>
                 <time>1584202093.9701</time>
-                <description>/firewall_rules_edit.php made changes</description>
+                <descr>/firewall_rules_edit.php made changes</descr>
                 </updated>
                 <created>
                 <username>root@10.0.5.2</username>
                 <time>1584202093.9701</time>
-                <description>/firewall_rules_edit.php made changes</description>
+                <descr>/firewall_rules_edit.php made changes</descr>
                 </created>
                 </rule>
                 </filter>

--- a/tests/unit/plugins/module_utils/test_interfaces_configuration_utils.py
+++ b/tests/unit/plugins/module_utils/test_interfaces_configuration_utils.py
@@ -1133,8 +1133,8 @@ def test_simple_interface_configuration_from_xml_to_etree():
         test_etree_interface_configuration
     )
     assert test_interface_configuration.identifier == "opt1"
-    assert test_interface_configuration.device == "em3"
-    assert test_interface_configuration.descr == "DMZ"
+    assert test_interface_configuration.extra_attrs["if"] == "em3"
+    assert test_interface_configuration.extra_attrs["descr"] == "DMZ"
 
     orig_etree: Element = ElementTree.fromstring(TEST_XML)
     orig_test_interface_configuration: Element = list(list(test_etree_opnsense)[4])[2]
@@ -1160,8 +1160,8 @@ def test_wan_interface_configuration_to_etree():
         blockpriv=1,
         ipaddrv6="dhcp6",
         lock=1,
+        dhcp6_ia_pd_len="0"
     )
-    setattr(test_interface_configuration, "dhcp6-ia-pd-len", "0")
 
     test_element = test_interface_configuration.to_etree()
     orig_etree: Element = ElementTree.fromstring(TEST_XML)
@@ -1182,9 +1182,9 @@ def test_lan_interface_configuration_to_etree():
         blockbogons=1,
         ipaddrv6="track6",
         lock=1,
+        track6_interface="wan",
+        track6_prefix_id="0"
     )
-    setattr(test_interface_configuration, "track6-interface", "wan")
-    setattr(test_interface_configuration, "track6-prefix-id", "0")
 
     test_element = test_interface_configuration.to_etree()
     orig_etree: Element = ElementTree.fromstring(TEST_XML)
@@ -1229,10 +1229,9 @@ def test_opt2_interface_configuration_to_etree():
         adv_dhcp_config_advanced=None,
         adv_dhcp_config_file_override=None,
         adv_dhcp_config_file_override_path=None,
+        alias_address=None,
+        alias_subnet=32,
     )
-
-    setattr(test_interface_configuration, "alias-address", None)
-    setattr(test_interface_configuration, "alias-subnet", "32")
 
     test_element = test_interface_configuration.to_etree()
 
@@ -1277,8 +1276,8 @@ def test_simple_interface_configuration_from_ansible_module_params_simple(
         InterfaceConfiguration.from_ansible_module_params(test_params)
     )
     assert test_interface_configuration.identifier == "wan"
-    assert test_interface_configuration.device == "vtnet1"
-    assert test_interface_configuration.descr == "lan_interface"
+    assert test_interface_configuration.extra_attrs["if"] == "vtnet1"
+    assert test_interface_configuration.extra_attrs["descr"] == "lan_interface"
 
 
 @patch(
@@ -1310,8 +1309,8 @@ def test_interface_configuration_from_ansible_module_params_with_description_upd
     with InterfacesSet(sample_config_path) as new_interfaces_set:
         new_test_interface_configuration = new_interfaces_set.find(identifier="lan")
         assert new_test_interface_configuration.identifier == "lan"
-        assert new_test_interface_configuration.device == "em1"
-        assert new_test_interface_configuration.descr == "test_interface"
+        assert new_test_interface_configuration.extra_attrs["if"] == "em1"
+        assert new_test_interface_configuration.extra_attrs["descr"] == "test_interface"
         new_interfaces_set.save()
 
 
@@ -1343,8 +1342,8 @@ def test_interface_configuration_from_ansible_module_params_with_device_update(
     with InterfacesSet(sample_config_path) as new_interfaces_set:
         new_test_interface_configuration = new_interfaces_set.find(identifier="wan")
         assert new_test_interface_configuration.identifier == "wan"
-        assert new_test_interface_configuration.device == "em4"
-        assert new_test_interface_configuration.descr == "test_interface"
+        assert new_test_interface_configuration.extra_attrs["if"] == "em4"
+        assert new_test_interface_configuration.extra_attrs["descr"] == "test_interface"
         new_interfaces_set.save()
 
 
@@ -1433,8 +1432,8 @@ def test_interface_configuration_from_ansible_module_params_with_not_existing_id
     with InterfacesSet(sample_config_path) as new_interfaces_set:
         new_test_interface_configuration = new_interfaces_set.find(identifier="test")
         assert new_test_interface_configuration.identifier == "test"
-        assert new_test_interface_configuration.device == "em4"
-        assert new_test_interface_configuration.descr == "test_interface"
+        assert new_test_interface_configuration.extra_attrs["if"] == "em4"
+        assert new_test_interface_configuration.extra_attrs["descr"] == "test_interface"
         new_interfaces_set.save()
 
 

--- a/tests/unit/plugins/module_utils/test_interfaces_configuration_utils.py
+++ b/tests/unit/plugins/module_utils/test_interfaces_configuration_utils.py
@@ -12,7 +12,7 @@ from ansible_collections.puzzle.opnsense.plugins.module_utils import xml_utils
 from ansible_collections.puzzle.opnsense.plugins.module_utils.interfaces_configuration_utils import (
     InterfaceConfiguration,
     InterfacesSet,
-    OPNSenseDeviceNotFoundError,
+    OPNSenseInterfaceNotFoundError,
     OPNSenseDeviceAlreadyAssignedError,
     OPNSenseGetInterfacesError,
 )
@@ -1366,13 +1366,13 @@ def test_interface_configuration_from_ansible_module_params_with_not_existing_de
         "description": "test_interface",
     }
     with InterfacesSet(sample_config_path) as interfaces_set:
-        with pytest.raises(OPNSenseDeviceNotFoundError) as excinfo:
+        with pytest.raises(OPNSenseInterfaceNotFoundError) as excinfo:
             test_interface_configuration: InterfaceConfiguration = (
                 InterfaceConfiguration.from_ansible_module_params(test_params)
             )
             interfaces_set.update(test_interface_configuration)
             interfaces_set.save()
-        assert "Device was not found on OPNsense Instance!" in str(excinfo.value)
+        assert "Interface was not found on OPNsense Instance!" in str(excinfo.value)
 
 
 @patch(

--- a/tests/unit/plugins/module_utils/test_interfaces_configuration_utils.py
+++ b/tests/unit/plugins/module_utils/test_interfaces_configuration_utils.py
@@ -206,7 +206,7 @@ TEST_XML: str = """<?xml version="1.0"?>
                     <dnsallowoverride/>
                     <group>
                     <name>admins</name>
-                    <description>System Administrators</description>
+                    <descr>System Administrators</descr>
                     <scope>system</scope>
                     <gid>1999</gid>
                     <member>0</member>
@@ -525,7 +525,7 @@ TEST_XML: str = """<?xml version="1.0"?>
                 <revision>
                 <username>(root)</username>
                 <time>1712239765.0467</time>
-                <description>Updated plugin interface configuration</description>
+                <descr>Updated plugin interface configuration</descr>
                 </revision>
                 <OPNsense>
                 <captiveportal version="1.0.1">
@@ -632,12 +632,12 @@ TEST_XML: str = """<?xml version="1.0"?>
                 <events/>
                 <format/>
                 <reminder>10</reminder>
-                <description/>
+                <descr/>
                 </alert>
                 <service uuid="f85a8cf8-a81e-4cf4-8cb0-c1fc2b10cb24">
                 <enabled>1</enabled>
                 <name>$HOST</name>
-                <description/>
+                <descr/>
                 <type>system</type>
                 <pidfile/>
                 <match/>
@@ -655,7 +655,7 @@ TEST_XML: str = """<?xml version="1.0"?>
                 <service uuid="12aabe3a-3671-496d-aa9e-aa2018c766e3">
                 <enabled>1</enabled>
                 <name>RootFs</name>
-                <description/>
+                <descr/>
                 <type>filesystem</type>
                 <pidfile/>
                 <match/>
@@ -673,7 +673,7 @@ TEST_XML: str = """<?xml version="1.0"?>
                 <service uuid="325389a3-13df-4679-b0d3-1d238a83787b">
                 <enabled>0</enabled>
                 <name>carp_status_change</name>
-                <description/>
+                <descr/>
                 <type>custom</type>
                 <pidfile/>
                 <match/>
@@ -691,7 +691,7 @@ TEST_XML: str = """<?xml version="1.0"?>
                 <service uuid="9c07f6fd-c55a-43fa-9513-363ac364b383">
                 <enabled>0</enabled>
                 <name>gateway_alert</name>
-                <description/>
+                <descr/>
                 <type>custom</type>
                 <pidfile/>
                 <match/>
@@ -1271,7 +1271,7 @@ def test_simple_interface_configuration_from_ansible_module_params_simple(
     test_params: dict = {
         "identifier": "wan",
         "device": "vtnet1",
-        "description": "lan_interface",
+        "descr": "lan_interface",
     }
     test_interface_configuration: InterfaceConfiguration = (
         InterfaceConfiguration.from_ansible_module_params(test_params)
@@ -1296,7 +1296,7 @@ def test_interface_configuration_from_ansible_module_params_with_description_upd
     test_params: dict = {
         "identifier": "lan",
         "device": "em1",
-        "description": "test_interface",
+        "descr": "test_interface",
     }
     with InterfacesSet(sample_config_path) as interfaces_set:
         test_interface_configuration: InterfaceConfiguration = (
@@ -1330,7 +1330,7 @@ def test_interface_configuration_from_ansible_module_params_with_device_update(
     test_params: dict = {
         "identifier": "wan",
         "device": "em4",
-        "description": "test_interface",
+        "descr": "test_interface",
     }
     with InterfacesSet(sample_config_path) as interfaces_set:
         test_interface_configuration: InterfaceConfiguration = (
@@ -1363,7 +1363,7 @@ def test_interface_configuration_from_ansible_module_params_with_not_existing_de
     test_params: dict = {
         "identifier": "wan",
         "device": "test",
-        "description": "test_interface",
+        "descr": "test_interface",
     }
     with InterfacesSet(sample_config_path) as interfaces_set:
         with pytest.raises(OPNSenseInterfaceNotFoundError) as excinfo:
@@ -1390,7 +1390,7 @@ def test_interface_configuration_from_ansible_module_params_with_not_existing_id
     test_params: dict = {
         "identifier": "test",
         "device": "em0",
-        "description": "test_interface",
+        "descr": "test_interface",
     }
     with InterfacesSet(sample_config_path) as interfaces_set:
         with pytest.raises(OPNSenseDeviceAlreadyAssignedError) as excinfo:
@@ -1420,7 +1420,7 @@ def test_interface_configuration_from_ansible_module_params_with_not_existing_id
     test_params: dict = {
         "identifier": "test",
         "device": "em4",
-        "description": "test_interface",
+        "descr": "test_interface",
     }
     with InterfacesSet(sample_config_path) as interfaces_set:
         test_interface_configuration: InterfaceConfiguration = (
@@ -1453,7 +1453,7 @@ def test_interface_configuration_from_ansible_module_params_with_duplicate_devic
     test_params: dict = {
         "identifier": "wan",
         "device": "em1",
-        "description": "duplicate device",
+        "descr": "duplicate device",
     }
     with InterfacesSet(sample_config_path) as interfaces_set:
         with pytest.raises(OPNSenseDeviceAlreadyAssignedError) as excinfo:

--- a/tests/unit/plugins/module_utils/test_interfaces_configuration_utils.py
+++ b/tests/unit/plugins/module_utils/test_interfaces_configuration_utils.py
@@ -12,7 +12,7 @@ import pytest
 
 from ansible_collections.puzzle.opnsense.plugins.module_utils import xml_utils
 from ansible_collections.puzzle.opnsense.plugins.module_utils.interfaces_configuration_utils import (
-    InterfaceAssignment,
+    InterfaceConfiguration,
     InterfacesSet,
     OPNSenseDeviceNotFoundError,
     OPNSenseDeviceAlreadyAssignedError,
@@ -1126,27 +1126,27 @@ def sample_config_path(request):
     os.unlink(temp_file.name)
 
 
-def test_simple_interface_assignment_from_xml_to_etree():
+def test_simple_interface_configuration_from_xml_to_etree():
     test_etree_opnsense: Element = ElementTree.fromstring(TEST_XML)
 
-    test_etree_interface_assignment: Element = list(list(test_etree_opnsense)[4])[2]
-    test_interface_assignment: InterfaceAssignment = InterfaceAssignment.from_xml(
-        test_etree_interface_assignment
+    test_etree_interface_configuration: Element = list(list(test_etree_opnsense)[4])[2]
+    test_interface_configuration: InterfaceConfiguration = InterfaceConfiguration.from_xml(
+        test_etree_interface_configuration
     )
-    assert test_interface_assignment.identifier == "opt1"
-    assert test_interface_assignment.device == "em3"
-    assert test_interface_assignment.descr == "DMZ"
+    assert test_interface_configuration.identifier == "opt1"
+    assert test_interface_configuration.device == "em3"
+    assert test_interface_configuration.descr == "DMZ"
 
     orig_etree: Element = ElementTree.fromstring(TEST_XML)
-    orig_test_interface_assignment: Element = list(list(test_etree_opnsense)[4])[2]
+    orig_test_interface_configuration: Element = list(list(test_etree_opnsense)[4])[2]
 
     assert xml_utils.elements_equal(
-        test_interface_assignment.to_etree(), orig_test_interface_assignment
+        test_interface_configuration.to_etree(), orig_test_interface_configuration
     )
 
 
-def test_wan_interface_assignment_to_etree():
-    test_interface_assignment: InterfaceAssignment = InterfaceAssignment(
+def test_wan_interface_configuration_to_etree():
+    test_interface_configuration: InterfaceConfiguration = InterfaceConfiguration(
         identifier="wan",
         device="em2",
         descr="WAN",
@@ -1162,17 +1162,17 @@ def test_wan_interface_assignment_to_etree():
         ipaddrv6="dhcp6",
         lock=1,
     )
-    setattr(test_interface_assignment, "dhcp6-ia-pd-len", "0")
+    setattr(test_interface_configuration, "dhcp6-ia-pd-len", "0")
 
-    test_element = test_interface_assignment.to_etree()
+    test_element = test_interface_configuration.to_etree()
     orig_etree: Element = ElementTree.fromstring(TEST_XML)
-    orig_test_interface_assignment: Element = list(list(orig_etree)[4])[0]
+    orig_test_interface_configuration: Element = list(list(orig_etree)[4])[0]
 
-    assert xml_utils.elements_equal(test_element, orig_test_interface_assignment)
+    assert xml_utils.elements_equal(test_element, orig_test_interface_configuration)
 
 
-def test_lan_interface_assignment_to_etree():
-    test_interface_assignment: InterfaceAssignment = InterfaceAssignment(
+def test_lan_interface_configuration_to_etree():
+    test_interface_configuration: InterfaceConfiguration = InterfaceConfiguration(
         identifier="lan",
         device="em1",
         enable=1,
@@ -1184,29 +1184,29 @@ def test_lan_interface_assignment_to_etree():
         ipaddrv6="track6",
         lock=1,
     )
-    setattr(test_interface_assignment, "track6-interface", "wan")
-    setattr(test_interface_assignment, "track6-prefix-id", "0")
+    setattr(test_interface_configuration, "track6-interface", "wan")
+    setattr(test_interface_configuration, "track6-prefix-id", "0")
 
-    test_element = test_interface_assignment.to_etree()
+    test_element = test_interface_configuration.to_etree()
     orig_etree: Element = ElementTree.fromstring(TEST_XML)
-    orig_test_interface_assignment: Element = list(list(orig_etree)[4])[1]
+    orig_test_interface_configuration: Element = list(list(orig_etree)[4])[1]
 
-    assert xml_utils.elements_equal(test_element, orig_test_interface_assignment)
+    assert xml_utils.elements_equal(test_element, orig_test_interface_configuration)
 
 
-def test_opt1_interface_assignment_to_etree():
-    test_interface_assignment: InterfaceAssignment = InterfaceAssignment(
+def test_opt1_interface_configuration_to_etree():
+    test_interface_configuration: InterfaceConfiguration = InterfaceConfiguration(
         identifier="opt1", device="em3", descr="DMZ", spoofmac=None, lock=1
     )
-    test_element = test_interface_assignment.to_etree()
+    test_element = test_interface_configuration.to_etree()
     orig_etree: Element = ElementTree.fromstring(TEST_XML)
-    orig_test_interface_assignment: Element = list(list(orig_etree)[4])[2]
+    orig_test_interface_configuration: Element = list(list(orig_etree)[4])[2]
 
-    assert xml_utils.elements_equal(test_element, orig_test_interface_assignment)
+    assert xml_utils.elements_equal(test_element, orig_test_interface_configuration)
 
 
-def test_opt2_interface_assignment_to_etree():
-    test_interface_assignment: InterfaceAssignment = InterfaceAssignment(
+def test_opt2_interface_configuration_to_etree():
+    test_interface_configuration: InterfaceConfiguration = InterfaceConfiguration(
         identifier="opt2",
         device="em0",
         descr="VAGRANT",
@@ -1232,19 +1232,19 @@ def test_opt2_interface_assignment_to_etree():
         adv_dhcp_config_file_override_path=None,
     )
 
-    setattr(test_interface_assignment, "alias-address", None)
-    setattr(test_interface_assignment, "alias-subnet", "32")
+    setattr(test_interface_configuration, "alias-address", None)
+    setattr(test_interface_configuration, "alias-subnet", "32")
 
-    test_element = test_interface_assignment.to_etree()
+    test_element = test_interface_configuration.to_etree()
 
     orig_etree: Element = ElementTree.fromstring(TEST_XML)
-    orig_test_interface_assignment: Element = list(list(orig_etree)[4])[3]
+    orig_test_interface_configuration: Element = list(list(orig_etree)[4])[3]
 
-    assert xml_utils.elements_equal(test_element, orig_test_interface_assignment)
+    assert xml_utils.elements_equal(test_element, orig_test_interface_configuration)
 
 
-def test_lo0_interface_assignment_to_etree():
-    test_interface_assignment: InterfaceAssignment = InterfaceAssignment(
+def test_lo0_interface_configuration_to_etree():
+    test_interface_configuration: InterfaceConfiguration = InterfaceConfiguration(
         internal_dynamic="1",
         identifier="lo0",
         device="lo0",
@@ -1258,15 +1258,15 @@ def test_lo0_interface_assignment_to_etree():
         virtual="1",
     )
 
-    test_element = test_interface_assignment.to_etree()
+    test_element = test_interface_configuration.to_etree()
 
     orig_etree: Element = ElementTree.fromstring(TEST_XML)
-    orig_test_interface_assignment: Element = list(list(orig_etree)[4])[4]
+    orig_test_interface_configuration: Element = list(list(orig_etree)[4])[4]
 
-    assert xml_utils.elements_equal(test_element, orig_test_interface_assignment)
+    assert xml_utils.elements_equal(test_element, orig_test_interface_configuration)
 
 
-def test_simple_interface_assignment_from_ansible_module_params_simple(
+def test_simple_interface_configuration_from_ansible_module_params_simple(
     sample_config_path,
 ):
     test_params: dict = {
@@ -1274,12 +1274,12 @@ def test_simple_interface_assignment_from_ansible_module_params_simple(
         "device": "vtnet1",
         "description": "lan_interface",
     }
-    test_interface_assignment: InterfaceAssignment = (
-        InterfaceAssignment.from_ansible_module_params(test_params)
+    test_interface_configuration: InterfaceConfiguration = (
+        InterfaceConfiguration.from_ansible_module_params(test_params)
     )
-    assert test_interface_assignment.identifier == "wan"
-    assert test_interface_assignment.device == "vtnet1"
-    assert test_interface_assignment.descr == "lan_interface"
+    assert test_interface_configuration.identifier == "wan"
+    assert test_interface_configuration.device == "vtnet1"
+    assert test_interface_configuration.descr == "lan_interface"
 
 
 @patch(
@@ -1291,7 +1291,7 @@ def test_simple_interface_assignment_from_ansible_module_params_simple(
     return_value=["em1", "em2", "em3", "em4"],
 )
 @patch.dict(in_dict=VERSION_MAP, values=TEST_VERSION_MAP, clear=True)
-def test_interface_assignment_from_ansible_module_params_with_description_update(
+def test_interface_configuration_from_ansible_module_params_with_description_update(
     mock_get_version, mock_get_interfaces, sample_config_path
 ):
     test_params: dict = {
@@ -1300,19 +1300,19 @@ def test_interface_assignment_from_ansible_module_params_with_description_update
         "description": "test_interface",
     }
     with InterfacesSet(sample_config_path) as interfaces_set:
-        test_interface_assignment: InterfaceAssignment = (
-            InterfaceAssignment.from_ansible_module_params(test_params)
+        test_interface_configuration: InterfaceConfiguration = (
+            InterfaceConfiguration.from_ansible_module_params(test_params)
         )
-        interfaces_set.update(test_interface_assignment)
+        interfaces_set.update(test_interface_configuration)
         assert interfaces_set.changed
 
         interfaces_set.save()
 
     with InterfacesSet(sample_config_path) as new_interfaces_set:
-        new_test_interface_assignment = new_interfaces_set.find(identifier="lan")
-        assert new_test_interface_assignment.identifier == "lan"
-        assert new_test_interface_assignment.device == "em1"
-        assert new_test_interface_assignment.descr == "test_interface"
+        new_test_interface_configuration = new_interfaces_set.find(identifier="lan")
+        assert new_test_interface_configuration.identifier == "lan"
+        assert new_test_interface_configuration.device == "em1"
+        assert new_test_interface_configuration.descr == "test_interface"
         new_interfaces_set.save()
 
 
@@ -1325,7 +1325,7 @@ def test_interface_assignment_from_ansible_module_params_with_description_update
     return_value=["em0", "em1", "em2", "em3", "em4"],
 )
 @patch.dict(in_dict=VERSION_MAP, values=TEST_VERSION_MAP, clear=True)
-def test_interface_assignment_from_ansible_module_params_with_device_update(
+def test_interface_configuration_from_ansible_module_params_with_device_update(
     mock_get_version, mock_get_interfaces, sample_config_path
 ):
     test_params: dict = {
@@ -1334,18 +1334,18 @@ def test_interface_assignment_from_ansible_module_params_with_device_update(
         "description": "test_interface",
     }
     with InterfacesSet(sample_config_path) as interfaces_set:
-        test_interface_assignment: InterfaceAssignment = (
-            InterfaceAssignment.from_ansible_module_params(test_params)
+        test_interface_configuration: InterfaceConfiguration = (
+            InterfaceConfiguration.from_ansible_module_params(test_params)
         )
-        interfaces_set.update(test_interface_assignment)
+        interfaces_set.update(test_interface_configuration)
         assert interfaces_set.changed
         interfaces_set.save()
 
     with InterfacesSet(sample_config_path) as new_interfaces_set:
-        new_test_interface_assignment = new_interfaces_set.find(identifier="wan")
-        assert new_test_interface_assignment.identifier == "wan"
-        assert new_test_interface_assignment.device == "em4"
-        assert new_test_interface_assignment.descr == "test_interface"
+        new_test_interface_configuration = new_interfaces_set.find(identifier="wan")
+        assert new_test_interface_configuration.identifier == "wan"
+        assert new_test_interface_configuration.device == "em4"
+        assert new_test_interface_configuration.descr == "test_interface"
         new_interfaces_set.save()
 
 
@@ -1358,7 +1358,7 @@ def test_interface_assignment_from_ansible_module_params_with_device_update(
     return_value=["em0", "em1", "em2", "em3", "em4"],
 )
 @patch.dict(in_dict=VERSION_MAP, values=TEST_VERSION_MAP, clear=True)
-def test_interface_assignment_from_ansible_module_params_with_not_existing_device(
+def test_interface_configuration_from_ansible_module_params_with_not_existing_device(
     mock_get_version, mock_get_interfaces, sample_config_path
 ):
     test_params: dict = {
@@ -1368,10 +1368,10 @@ def test_interface_assignment_from_ansible_module_params_with_not_existing_devic
     }
     with InterfacesSet(sample_config_path) as interfaces_set:
         with pytest.raises(OPNSenseDeviceNotFoundError) as excinfo:
-            test_interface_assignment: InterfaceAssignment = (
-                InterfaceAssignment.from_ansible_module_params(test_params)
+            test_interface_configuration: InterfaceConfiguration = (
+                InterfaceConfiguration.from_ansible_module_params(test_params)
             )
-            interfaces_set.update(test_interface_assignment)
+            interfaces_set.update(test_interface_configuration)
             interfaces_set.save()
         assert "Device was not found on OPNsense Instance!" in str(excinfo.value)
 
@@ -1385,7 +1385,7 @@ def test_interface_assignment_from_ansible_module_params_with_not_existing_devic
     return_value=["em0", "em1", "em2", "em3", "em4"],
 )
 @patch.dict(in_dict=VERSION_MAP, values=TEST_VERSION_MAP, clear=True)
-def test_interface_assignment_from_ansible_module_params_with_not_existing_identifier_and_used_device(
+def test_interface_configuration_from_ansible_module_params_with_not_existing_identifier_and_used_device(
     mock_get_version, mock_get_interfaces, sample_config_path
 ):
     test_params: dict = {
@@ -1395,10 +1395,10 @@ def test_interface_assignment_from_ansible_module_params_with_not_existing_ident
     }
     with InterfacesSet(sample_config_path) as interfaces_set:
         with pytest.raises(OPNSenseDeviceAlreadyAssignedError) as excinfo:
-            test_interface_assignment: InterfaceAssignment = (
-                InterfaceAssignment.from_ansible_module_params(test_params)
+            test_interface_configuration: InterfaceConfiguration = (
+                InterfaceConfiguration.from_ansible_module_params(test_params)
             )
-            interfaces_set.update(test_interface_assignment)
+            interfaces_set.update(test_interface_configuration)
             interfaces_set.save()
         assert (
             "This device is already assigned, please unassign this device first"
@@ -1415,7 +1415,7 @@ def test_interface_assignment_from_ansible_module_params_with_not_existing_ident
     return_value=["em0", "em1", "em2", "em3", "em4"],
 )
 @patch.dict(in_dict=VERSION_MAP, values=TEST_VERSION_MAP, clear=True)
-def test_interface_assignment_from_ansible_module_params_with_not_existing_identifier_and_not_used_device(
+def test_interface_configuration_from_ansible_module_params_with_not_existing_identifier_and_not_used_device(
     mock_get_version, mock_get_interfaces, sample_config_path
 ):
     test_params: dict = {
@@ -1424,18 +1424,18 @@ def test_interface_assignment_from_ansible_module_params_with_not_existing_ident
         "description": "test_interface",
     }
     with InterfacesSet(sample_config_path) as interfaces_set:
-        test_interface_assignment: InterfaceAssignment = (
-            InterfaceAssignment.from_ansible_module_params(test_params)
+        test_interface_configuration: InterfaceConfiguration = (
+            InterfaceConfiguration.from_ansible_module_params(test_params)
         )
-        interfaces_set.update(test_interface_assignment)
+        interfaces_set.update(test_interface_configuration)
         assert interfaces_set.changed
         interfaces_set.save()
 
     with InterfacesSet(sample_config_path) as new_interfaces_set:
-        new_test_interface_assignment = new_interfaces_set.find(identifier="test")
-        assert new_test_interface_assignment.identifier == "test"
-        assert new_test_interface_assignment.device == "em4"
-        assert new_test_interface_assignment.descr == "test_interface"
+        new_test_interface_configuration = new_interfaces_set.find(identifier="test")
+        assert new_test_interface_configuration.identifier == "test"
+        assert new_test_interface_configuration.device == "em4"
+        assert new_test_interface_configuration.descr == "test_interface"
         new_interfaces_set.save()
 
 
@@ -1448,7 +1448,7 @@ def test_interface_assignment_from_ansible_module_params_with_not_existing_ident
     return_value=["em0", "em1", "em2", "em3", "em4"],
 )
 @patch.dict(in_dict=VERSION_MAP, values=TEST_VERSION_MAP, clear=True)
-def test_interface_assignment_from_ansible_module_params_with_duplicate_device(
+def test_interface_configuration_from_ansible_module_params_with_duplicate_device(
     mock_get_version, mock_get_interfaces, sample_config_path
 ):
     test_params: dict = {
@@ -1458,10 +1458,10 @@ def test_interface_assignment_from_ansible_module_params_with_duplicate_device(
     }
     with InterfacesSet(sample_config_path) as interfaces_set:
         with pytest.raises(OPNSenseDeviceAlreadyAssignedError) as excinfo:
-            test_interface_assignment: InterfaceAssignment = (
-                InterfaceAssignment.from_ansible_module_params(test_params)
+            test_interface_configuration: InterfaceConfiguration = (
+                InterfaceConfiguration.from_ansible_module_params(test_params)
             )
-            interfaces_set.update(test_interface_assignment)
+            interfaces_set.update(test_interface_configuration)
             interfaces_set.save()
         assert (
             "This device is already assigned, please unassign this device first"


### PR DESCRIPTION
Changes resulting from the review of [kdhlab:interface_config](https://github.com/kdhlab/puzzle.opnsense/tree/interface_config)

Main changes are regarding the following aspects of the originally suggested changes:
1. Renaming `InterfaceAssignment` to `InterfaceConfiguration` in other unit tests and docstrings.
2. Fixing the unit tests (this required some modifications to `InterfaceConfiguration:save`, `InterfaceConfiguration:add_or_update`, and the handling of `InterfaceConfiguration:extra_attr`).

See https://github.com/puzzle/puzzle.opnsense/pull/158